### PR TITLE
Support ElasticSearch 6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
       # - image: circleci/mysql:9.4
-      - image: elasticsearch:5.5.2
+      - image: docker.elastic.co/elasticsearch/elasticsearch:6.0.0
 
     working_directory: ~/repo
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ All following tools are running by [circleci](https://circleci.com/gh/Nexucis/es
 If you want to launch the unit test, you need to have a local elasticsearch instance which must be accessible through the url http://localhost:9200. A simply way to launch it, is to start the [corresponding container](https://hub.docker.com/_/elasticsearch/) : 
 
 ```bash
-docker run -d -p 9200:9200 -p 9300:9300 elasticsearch:5.5.2
+docker run -d -p 9200:9200 docker.elastic.co/elasticsearch/elasticsearch:6.0.0
 ```
 
 Once ElasticSearch is up, you can run the following command :

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ It all begins with an index creation :
 ```php
 <?php
 $alias = "myindex";
-$helper->createIndex($alias);
+$helper->createIndexByAlias($alias);
 ```
 
 As you can see, we pass an alias name and not and index name through the helper. With the Helper, you will see everything through an alias and not the index directly. 
@@ -113,7 +113,7 @@ As we say, with this helper, you will see everything through an alias. So if you
 ```php
 <?php
 $alias= 'myindex';
-$helper->deleteIndex($alias);
+$helper->deleteIndexByAlias($alias);
 ```
 
 And if you perform the previous HTTP request, you will see that there is nothing left. The alias AND the index has been removed. 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": "^7.0",
-    "elasticsearch/elasticsearch": "5.3.1"
+    "elasticsearch/elasticsearch": "6.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.4",

--- a/src/Nexucis/Elasticsearch/Helper/Nodowntime/IndexHelper.php
+++ b/src/Nexucis/Elasticsearch/Helper/Nodowntime/IndexHelper.php
@@ -83,24 +83,6 @@ class IndexHelper implements IndexHelperInterface
     }
 
     /**
-     * @param $index : index or alias can put here [REQUIRED]
-     * @return void
-     * @throws IndexNotFoundException
-     */
-    public function deleteIndex($index)
-    {
-        $params = array(
-            'index' => $index
-        );
-
-        if (!$this->existsIndex($index)) {
-            throw new IndexNotFoundException($index);
-        }
-
-        $this->client->indices()->delete($params);
-    }
-
-    /**
      * @param $alias : alias can put here [REQUIRED]
      * @return void
      * @throws IndexNotFoundException
@@ -603,6 +585,24 @@ class IndexHelper implements IndexHelperInterface
         $response = $this->client->index($params);
 
         return $response['_version'];
+    }
+
+    /**
+     * @param $index : index can put here [REQUIRED]
+     * @return void
+     * @throws IndexNotFoundException
+     */
+    protected function deleteIndex($index)
+    {
+        $params = array(
+            'index' => $index
+        );
+
+        if (!$this->existsIndex($index)) {
+            throw new IndexNotFoundException($index);
+        }
+
+        $this->client->indices()->delete($params);
     }
 
     /**

--- a/src/Nexucis/Elasticsearch/Helper/Nodowntime/IndexHelper.php
+++ b/src/Nexucis/Elasticsearch/Helper/Nodowntime/IndexHelper.php
@@ -63,7 +63,7 @@ class IndexHelper implements IndexHelperInterface
      * @return void
      * @throws IndexAlreadyExistException
      */
-    public function createIndex($alias)
+    public function createIndexByAlias($alias)
     {
         $index = $alias . self::INDEX_NAME_CONVENTION_1;
 

--- a/src/Nexucis/Elasticsearch/Helper/Nodowntime/IndexHelper.php
+++ b/src/Nexucis/Elasticsearch/Helper/Nodowntime/IndexHelper.php
@@ -101,6 +101,24 @@ class IndexHelper implements IndexHelperInterface
     }
 
     /**
+     * @param $alias : alias can put here [REQUIRED]
+     * @return void
+     * @throws IndexNotFoundException
+     */
+    public function deleteIndexByAlias($alias)
+    {
+        if (!$this->existsIndex($alias)) {
+            throw new IndexNotFoundException($alias);
+        }
+
+        $params = array(
+            'index' => $this->findIndexByAlias($alias)
+        );
+
+        $this->client->indices()->delete($params);
+    }
+
+    /**
      * @param string $aliasSrc [REQUIRED]
      * @param string $aliasDest [REQUIRED]
      * @param string|bool $refresh wait until the result are visible to search

--- a/src/Nexucis/Elasticsearch/Helper/Nodowntime/IndexHelperInterface.php
+++ b/src/Nexucis/Elasticsearch/Helper/Nodowntime/IndexHelperInterface.php
@@ -35,13 +35,6 @@ interface IndexHelperInterface
     public function createIndexByAlias($alias);
 
     /**
-     * @param $index : index or alias can put here [REQUIRED]
-     * @return void
-     * @throws IndexNotFoundException
-     */
-    public function deleteIndex($index);
-
-    /**
      * @param $alias : alias can put here [REQUIRED]
      * @return void
      * @throws IndexNotFoundException

--- a/src/Nexucis/Elasticsearch/Helper/Nodowntime/IndexHelperInterface.php
+++ b/src/Nexucis/Elasticsearch/Helper/Nodowntime/IndexHelperInterface.php
@@ -42,6 +42,13 @@ interface IndexHelperInterface
     public function deleteIndex($index);
 
     /**
+     * @param $alias : alias can put here [REQUIRED]
+     * @return void
+     * @throws IndexNotFoundException
+     */
+    public function deleteIndexByAlias($alias);
+
+    /**
      * @param string $aliasSrc [REQUIRED]
      * @param string $aliasDest [REQUIRED]
      * @param string|bool $refresh wait until the result are visible to search

--- a/src/Nexucis/Elasticsearch/Helper/Nodowntime/IndexHelperInterface.php
+++ b/src/Nexucis/Elasticsearch/Helper/Nodowntime/IndexHelperInterface.php
@@ -32,7 +32,7 @@ interface IndexHelperInterface
      * @return void
      * @throws IndexAlreadyExistException
      */
-    public function createIndex($alias);
+    public function createIndexByAlias($alias);
 
     /**
      * @param $index : index or alias can put here [REQUIRED]

--- a/tests/Nexucis/Tests/Elasticsearch/Helper/Nodowntime/AbstractIndexHelperTest.php
+++ b/tests/Nexucis/Tests/Elasticsearch/Helper/Nodowntime/AbstractIndexHelperTest.php
@@ -61,7 +61,7 @@ abstract class AbstractIndexHelperTest extends TestCase
 
     protected function loadFinancialIndex($alias, $type = 'complains')
     {
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
 
         $this->addBulkDocuments($this->jsonArrayToBulkArray(self::$documents, $alias, $type));
     }

--- a/tests/Nexucis/Tests/Elasticsearch/Helper/Nodowntime/DocumentActionTest.php
+++ b/tests/Nexucis/Tests/Elasticsearch/Helper/Nodowntime/DocumentActionTest.php
@@ -37,8 +37,8 @@ class DocumentActionTest extends AbstractIndexHelperTest
     {
         $alias1 = 'financial';
         $alias2 = 'football';
-        $this->helper->createIndex($alias1);
-        $this->helper->createIndex($alias2);
+        $this->helper->createIndexByAlias($alias1);
+        $this->helper->createIndexByAlias($alias2);
 
         $aliases = $this->helper->getListAlias();
 
@@ -76,7 +76,7 @@ class DocumentActionTest extends AbstractIndexHelperTest
         ];
         $id = 'randomId';
 
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
 
         $this->assertTrue($this->helper->addDocument($alias, $type, $body, $id, true));
 
@@ -104,7 +104,7 @@ class DocumentActionTest extends AbstractIndexHelperTest
             'test' => 'Palatii dicto sciens venit contumaciter'
         ];
 
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
 
         $this->assertTrue($this->helper->addDocument($alias, $type, $body, $id));
 
@@ -133,7 +133,7 @@ class DocumentActionTest extends AbstractIndexHelperTest
             'test' => 'Palatii dicto sciens venit contumaciter'
         ];
 
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
 
         $this->assertTrue($this->helper->addDocument($alias, $type, $body, $id, true));
 
@@ -156,7 +156,7 @@ class DocumentActionTest extends AbstractIndexHelperTest
     {
         $type = 'test';
         $id = 0;
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
         $this->helper->deleteDocument($alias, $id, $type);
     }
 
@@ -174,7 +174,7 @@ class DocumentActionTest extends AbstractIndexHelperTest
      */
     public function testGetAllDocumentIndexEmpty($alias)
     {
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
         $result = $this->helper->getAllDocuments($alias);
 
         $this->assertTrue($result['hits']['total'] === 0);

--- a/tests/Nexucis/Tests/Elasticsearch/Helper/Nodowntime/IndexActionTest.php
+++ b/tests/Nexucis/Tests/Elasticsearch/Helper/Nodowntime/IndexActionTest.php
@@ -10,7 +10,7 @@ class IndexActionTest extends AbstractIndexHelperTest
      */
     public function testCreateIndex($alias)
     {
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
         $this->assertTrue($this->helper->existsIndex($alias));
         $this->assertTrue($this->helper->existsIndex($alias . $this->helper::INDEX_NAME_CONVENTION_1));
     }
@@ -21,8 +21,8 @@ class IndexActionTest extends AbstractIndexHelperTest
     public function testCreateIndexAlreadyExistsException()
     {
         $alias = 'myindextest';
-        $this->helper->createIndex($alias);
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
+        $this->helper->createIndexByAlias($alias);
     }
 
     /**
@@ -30,7 +30,7 @@ class IndexActionTest extends AbstractIndexHelperTest
      */
     public function testDeleteIndex($alias)
     {
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
         $this->helper->deleteIndex($alias);
 
         $this->assertFalse($this->helper->existsIndex($alias));
@@ -51,7 +51,7 @@ class IndexActionTest extends AbstractIndexHelperTest
      */
     public function testCopyEmptyIndex($alias)
     {
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
 
         $aliasDest = $alias . '2';
 
@@ -106,7 +106,7 @@ class IndexActionTest extends AbstractIndexHelperTest
     public function testCopyIndexAlreadyExistsException()
     {
         $aliasSrc = 'myindextest';
-        $this->helper->createIndex($aliasSrc);
+        $this->helper->createIndexByAlias($aliasSrc);
 
         $this->helper->copyIndex($aliasSrc, $aliasSrc);
     }
@@ -116,7 +116,7 @@ class IndexActionTest extends AbstractIndexHelperTest
      */
     public function testReindexEmptyIndex($alias)
     {
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
 
         $this->assertEquals($this->helper::RETURN_ACKNOWLEDGE, $this->helper->reindex($alias));
 

--- a/tests/Nexucis/Tests/Elasticsearch/Helper/Nodowntime/IndexActionTest.php
+++ b/tests/Nexucis/Tests/Elasticsearch/Helper/Nodowntime/IndexActionTest.php
@@ -31,7 +31,7 @@ class IndexActionTest extends AbstractIndexHelperTest
     public function testDeleteIndex($alias)
     {
         $this->helper->createIndexByAlias($alias);
-        $this->helper->deleteIndex($alias);
+        $this->helper->deleteIndexByAlias($alias);
 
         $this->assertFalse($this->helper->existsIndex($alias));
         $this->assertFalse($this->helper->existsIndex($alias . $this->helper::INDEX_NAME_CONVENTION_1));
@@ -43,7 +43,7 @@ class IndexActionTest extends AbstractIndexHelperTest
     public function testDeleteIndexNotFoundException()
     {
         $alias = 'myindextest';
-        $this->helper->deleteIndex($alias);
+        $this->helper->deleteIndexByAlias($alias);
     }
 
     /**

--- a/tests/Nexucis/Tests/Elasticsearch/Helper/Nodowntime/MappingsActionTest.php
+++ b/tests/Nexucis/Tests/Elasticsearch/Helper/Nodowntime/MappingsActionTest.php
@@ -10,7 +10,7 @@ class MappingsActionTest extends AbstractIndexHelperTest
      */
     public function testUpdateMappingsEmpty($alias)
     {
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
 
         $this->helper->updateMappings($alias, array());
 
@@ -24,7 +24,7 @@ class MappingsActionTest extends AbstractIndexHelperTest
      */
     public function testUpdateMappingsNull($alias)
     {
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
 
         $this->helper->updateMappings($alias, null);
 
@@ -62,7 +62,7 @@ class MappingsActionTest extends AbstractIndexHelperTest
             ]
         ];
 
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
 
         $this->helper->updateMappings($alias, $mapping);
         $this->assertTrue($this->helper->existsIndex($alias));
@@ -146,7 +146,7 @@ class MappingsActionTest extends AbstractIndexHelperTest
             ]
         ];
 
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
         $this->helper->updateSettings($alias, $settings);
 
         $this->helper->updateMappings($alias, $mapping);
@@ -175,7 +175,7 @@ class MappingsActionTest extends AbstractIndexHelperTest
      */
     public function testGetMappingsEmptyIndex($alias)
     {
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
 
         $this->assertEquals([], $this->helper->getMappings($alias));
     }

--- a/tests/Nexucis/Tests/Elasticsearch/Helper/Nodowntime/SettingsActionTest.php
+++ b/tests/Nexucis/Tests/Elasticsearch/Helper/Nodowntime/SettingsActionTest.php
@@ -12,7 +12,7 @@ class SettingsActionTest extends AbstractIndexHelperTest
     public function testAddSettingsEmpty()
     {
         $aliasSrc = 'myindextest';
-        $this->helper->createIndex($aliasSrc);
+        $this->helper->createIndexByAlias($aliasSrc);
 
         $this->helper->addSettings($aliasSrc, array());
     }
@@ -23,7 +23,7 @@ class SettingsActionTest extends AbstractIndexHelperTest
     public function testAddSettingsNull()
     {
         $aliasSrc = 'myindextest';
-        $this->helper->createIndex($aliasSrc);
+        $this->helper->createIndexByAlias($aliasSrc);
 
         $this->helper->addSettings($aliasSrc, null);
     }
@@ -42,7 +42,7 @@ class SettingsActionTest extends AbstractIndexHelperTest
      */
     public function testAddSettingsBasicData($alias)
     {
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
         $settings = [
             'analysis' => [
                 'filter' => [
@@ -91,7 +91,7 @@ class SettingsActionTest extends AbstractIndexHelperTest
      */
     public function testUpdateSettingsEmpty($alias)
     {
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
 
         $this->helper->updateSettings($alias, array());
 
@@ -105,7 +105,7 @@ class SettingsActionTest extends AbstractIndexHelperTest
      */
     public function testUpdateSettingsNull($alias)
     {
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
 
         $this->helper->updateSettings($alias, null);
 
@@ -158,7 +158,7 @@ class SettingsActionTest extends AbstractIndexHelperTest
                 ]
             ]
         ];
-        $this->helper->createIndex($alias);
+        $this->helper->createIndexByAlias($alias);
 
         $this->helper->updateSettings($alias, $settings);
 


### PR DESCRIPTION
## Feature
* Add new method `deleteIndexByAlias` which cannot be taken an index as parameter

## Breaking Changes

* Make `deleteIndex `protected
* Rename `createIndex `by `createIndexByAlias`