### PR TITLE
Simplify development commands run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run: php --ini
 
       # run tests!
-      - run: vendor/bin/phpunit
+      - run: composer test
 
       # run coverage
       - run: bash <(curl -s https://codecov.io/bash)
@@ -54,8 +54,8 @@ jobs:
           key: v1-dependencies-{{ checksum "composer.json" }}
 
       # run code analyzer
-      - run: vendor/bin/phpcs --standard=ruleset.xml --extensions=php --encoding=utf-8 --tab-width=4 src
-      - run: vendor/bin/phpcs --standard=ruleset.xml --extensions=php --encoding=utf-8 --tab-width=4 tests
+      - run: composer lint src
+      - run: composer lint tests
 
   analyze_phpstan:
     docker:
@@ -78,7 +78,7 @@ jobs:
           key: v1-dependencies-{{ checksum "composer.json" }}
 
       # run code analyzer
-      - run: vendor/bin/phpstan analyse --level 7 -c phpstan.neon src tests
+      - run: composer analyse src tests
   analyze_eol:
     docker:
       - image: nexucis/ci-checkfiles

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ docker run -d -p 9200:9200 docker.elastic.co/elasticsearch/elasticsearch:6.0.0
 Once ElasticSearch is up, you can run the following command :
 
 ```bash
-./vendor/bin/phpunit
+composer test
 ```
 
 ### Run PHP_CodeSniffer
@@ -243,8 +243,7 @@ This tool will check if the code respects some coding rules. In this project, we
 To launch it, run the following command :
 
 ```bash
-./vendor/bin/phpcs --standard=ruleset.xml --extensions=php --encoding=utf-8 --tab-width=4 src
-./vendor/bin/phpcs --standard=ruleset.xml --extensions=php --encoding=utf-8 --tab-width=4 tests
+composer lint src && composer lint tests
 ```
 
 If you are interesting by this tool, you can learn about it [here](https://github.com/squizlabs/PHP_CodeSniffer)
@@ -255,7 +254,7 @@ This tool wiil find some errors in the code without running it.
 To launch it, run the following command :
 
 ```bash
-./vendor/bin/phpstan analyse --level 7 -c phpstan.neon src
+composer analyse src
 ```
 
 If you are interesting by this tool, you can learn about it [here](https://github.com/phpstan/phpstan)

--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,10 @@
     "psr-4": {
       "Nexucis\\Tests\\": "tests/Nexucis/Tests"
     }
+  },
+  "scripts": {
+    "test": "./vendor/bin/phpunit",
+    "lint": "./vendor/bin/phpcs --standard=ruleset.xml --extensions=php --encoding=utf-8 --tab-width=4",
+    "analyse": "./vendor/bin/phpstan analyse --level 7 -c phpstan.neon"
   }
 }


### PR DESCRIPTION
Commands for code sniffer, test, etc are not friendly to remember. My proposal simplify it using composer scripts feature.